### PR TITLE
feat: Use custom datasource for reading tomcat release page

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "TOMCAT_VERSION" {
-    # renovate: datasource=github-tags depName=apache/tomcat
+    # renovate: datasource=tomcat depName=apache/tomcat
     default = "10.1.25"
 }
 

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,19 @@
       {
         "customType": "regex",
         "fileMatch": ["^docker-bake.hcl$"],
-        "matchStrings": ["datasource=(?<datasource>.*?) depName=(?<depName>apache\/tomcat)\n.*=\\s\"(?<currentValue>.*)\""]
+        "matchStrings": ["datasource=(?<datasource>.*?)\n.*=\\s\"(?<currentValue>.*)\""]
       }
-    ]
+  ],
+  "customDatasources": {
+    "tomcat": {
+      "defaultRegistryUrlTemplate": "https://dlcdn.apache.org/tomcat/tomcat-10/",
+      "format": "html"
+    }
+  },
+  "packageRules": [
+    {
+      "matchDatasources": ["tomcat"],
+      "extractVersion": "v(?<version>\\d+\\.\\d+\\.\\d+)"
+    }
+  ]
 }


### PR DESCRIPTION
Not all tags are available for download, so we should read the download directory instead.